### PR TITLE
suspend timer job for upper event-based gateway

### DIFF
--- a/src/test/java/org/camunda/bpm/unittest/DisableTimerExecutionListener.java
+++ b/src/test/java/org/camunda/bpm/unittest/DisableTimerExecutionListener.java
@@ -1,0 +1,62 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.bpm.unittest;
+
+import java.util.List;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.ExecutionListener;
+import org.camunda.bpm.engine.impl.context.Context;
+import org.camunda.bpm.engine.impl.interceptor.CommandContext;
+import org.camunda.bpm.engine.impl.interceptor.CommandContextListener;
+import org.camunda.bpm.engine.impl.persistence.entity.JobEntity;
+import org.camunda.bpm.engine.impl.persistence.entity.SuspensionState;
+
+/**
+ * @author Thorben Lindhauer
+ *
+ */
+public class DisableTimerExecutionListener implements ExecutionListener {
+
+  @Override
+  public void notify(DelegateExecution execution) throws Exception {
+    final String eventBasedGatewayExecutionId = execution.getId();
+
+    // wird am Ende der Transaktion, vor dem Flush in die Datenbank aufgerufen
+    Context.getCommandContext().registerCommandContextListener(new CommandContextListener() {
+
+      @Override
+      public void onCommandFailed(CommandContext commandContext, Throwable t) {
+      }
+
+      @Override
+      public void onCommandContextClose(CommandContext commandContext) {
+
+        List<JobEntity> jobs = commandContext.getDbEntityManager().getCachedEntitiesByType(JobEntity.class);
+        for (JobEntity job : jobs) {
+          // hier könnte man ggf noch weiter einschränken, falls es mehr als einen TimerJob für das exclusive Gateway gibt
+          if (eventBasedGatewayExecutionId.equals(job.getExecutionId())) {
+            job.setSuspensionState(SuspensionState.SUSPENDED.getStateCode());
+
+            // falls der Job sofort (bzw. vor dem nächsten Pollen durch den Job-Executor) due ist
+            // wird er direkt in dieser Queue abgelegt, sodass der Job-Executor ihn unmittelbar ausführt;
+            // entsprechend müssen wir ihn wieder entfernen
+            Context.getJobExecutorContext().getCurrentProcessorJobQueue().remove(job.getId());
+          }
+        }
+      }
+    });
+
+  }
+
+}

--- a/src/test/java/org/camunda/bpm/unittest/SimpleTestCase.java
+++ b/src/test/java/org/camunda/bpm/unittest/SimpleTestCase.java
@@ -13,10 +13,10 @@
 package org.camunda.bpm.unittest;
 
 import static java.util.Collections.singletonMap;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Map;
 
@@ -26,7 +26,6 @@ import org.camunda.bpm.engine.runtime.Job;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
-
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,7 +60,7 @@ public class SimpleTestCase {
 
     @Test
     @Deployment(resources = {"testProcess.bpmn"})
-    public void timerShouldBeActive() {
+    public void timerShouldBeSuspended() {
 
         RuntimeService runtimeService = rule.getRuntimeService();
         ManagementService managementService = rule.getManagementService();
@@ -71,14 +70,11 @@ public class SimpleTestCase {
         assertFalse("Process instance should not be ended", pi.isEnded());
 
         String id = pi.getProcessInstanceId();
-        Job timer = managementService.createJobQuery().processInstanceId(id).timers().active().singleResult();
+        Job timer = managementService.createJobQuery().processInstanceId(id).timers().singleResult();
 
-        Assert.assertNotNull("There should be an active timer", timer);
+        Assert.assertNotNull("There should be a suspended timer", timer);
         assertNotNull(timer.getDuedate());
-        managementService.executeJob(timer.getId());
-
-        // now the process instance should be ended
-        assertEquals("Process instance should be finished", 0, runtimeService.createProcessInstanceQuery().count());
+        assertTrue(timer.isSuspended());
 
     }
 

--- a/src/test/resources/testProcess.bpmn
+++ b/src/test/resources/testProcess.bpmn
@@ -2,6 +2,9 @@
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:camunda="http://activiti.org/bpmn" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" id="_7FrToMrfEeOyYYI9xhG4Cw" exporter="camunda modeler" exporterVersion="2.5.0" targetNamespace="http://activiti.org/bpmn">
   <bpmn2:process id="testProcess" isExecutable="true">
     <bpmn2:eventBasedGateway id="EventBasedGateway_1">
+      <bpmn2:extensionElements>
+        <camunda:executionListener class="org.camunda.bpm.unittest.DisableTimerExecutionListener" event="start"/>
+      </bpmn2:extensionElements>
       <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
       <bpmn2:outgoing>SequenceFlow_4</bpmn2:outgoing>
       <bpmn2:outgoing>SequenceFlow_10</bpmn2:outgoing>


### PR DESCRIPTION
Adds a "start" execution listener to the event-based gateway that in turn registers a command context listener. The command context listener is executed before the process engine flushes its state change to the database and suspends the timer job for the event-based gateway.
